### PR TITLE
Allow to specify env vars for use in the plan

### DIFF
--- a/.github/workflows/check-run.yml
+++ b/.github/workflows/check-run.yml
@@ -23,6 +23,16 @@ jobs:
       with:
         plan: '.github/workflows/zap/af-plan.yml'
 
+    - name: ZAP Plan Env Vars
+      uses: ./
+      id: af-plan-env-vars
+      env:
+        TARGET_URL: "http://localhost/"
+      with:
+        plan: '.github/workflows/zap/af-plan-env-vars.yml'
+        docker_env_vars: |
+          TARGET_URL
+
     - name: ZAP Plan with Error
       continue-on-error: true
       uses: ./

--- a/.github/workflows/zap/af-plan-env-vars.yml
+++ b/.github/workflows/zap/af-plan-env-vars.yml
@@ -1,0 +1,14 @@
+---
+env:
+  contexts:
+  - name: "Context"
+    urls:
+    - ${TARGET_URL}
+  parameters:
+    failOnError: true
+    failOnWarning: true
+    progressToStdout: true
+jobs:
+- requests:
+  - url: ${TARGET_URL}
+  type: "requestor"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ All notable changes to this GitHub action will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
+### Added
+ - Allow to specify the environment variables that should be passed to the Docker container to be used by the Automation Framework plan.
 
 ## [0.1.0] - 2024-04-23
 ### Added

--- a/README.md
+++ b/README.md
@@ -11,6 +11,17 @@ A GitHub Action for running [ZAP Automation Framework](https://www.zaproxy.org/d
 
 **Optional** if specified must not be empty. The name of the [ZAP Docker image](https://www.zaproxy.org/docs/docker/about/#install-instructions) to be used. By default the action runs the stable image.
 
+### `docker_env_vars`
+
+**Optional** The names of the environment variables that should be passed to the Docker container for use in the plan, e.g.:
+```yaml
+docker_env_vars: |
+  MY_TARGET_URL
+  MY_USER_NAME
+  MY_USER_PASSWORD
+```
+See also [Environment variables](#environment-variables).
+
 ### `cmd_options`
 
 **Optional** Additional [command line options](https://www.zaproxy.org/docs/desktop/cmdline/) for ZAP.
@@ -26,7 +37,7 @@ Files created with the plan that need to be used after the plan has finished sho
 ## Environment variables
 
 If set, the following [ZAP authentication environment variables](https://www.zaproxy.org/docs/authentication/handling-auth-yourself/#authentication-env-vars)
-will be copied into the docker container:
+will be copied into the Docker container:
 
 - `ZAP_AUTH_HEADER_VALUE`
 - `ZAP_AUTH_HEADER`
@@ -34,7 +45,7 @@ will be copied into the docker container:
 
 ## Example usage
 
-```
+```yaml
 steps:
   - name: ZAP Scan
     uses: zaproxy/action-af@v0.1.0

--- a/action.yml
+++ b/action.yml
@@ -11,6 +11,10 @@ inputs:
     description: 'The Docker image to be used.'
     required: true
     default: 'ghcr.io/zaproxy/zaproxy:stable'
+  docker_env_vars:
+    description: 'The env vars that should be passed to the Docker container running ZAP.'
+    required: false
+    default: ''
   cmd_options:
     description: 'Additional command line options to start ZAP with.'
     required: false

--- a/dist/index.js
+++ b/dist/index.js
@@ -28061,13 +28061,14 @@ async function run() {
     try {
         let workspace = process.env.GITHUB_WORKSPACE;
         let docker_name = core.getInput('docker_name', { required: true });
+        let dockerEnvVars = ["ZAP_AUTH_HEADER", "ZAP_AUTH_HEADER_VALUE", "ZAP_AUTH_HEADER_SITE"].concat(core.getMultilineInput('docker_env_vars', { required: false })).map(e => `-e ${e}`).join(' ');
         let plan = core.getInput('plan', { required: true });
         let cmdOptions = core.getInput('cmd_options');
 
         await exec.exec(`chmod a+w ${workspace}`);
 
         await exec.exec(`docker pull ${docker_name} -q`);
-        let command = (`docker run -v ${workspace}:/zap/wrk/:rw --network="host" -e ZAP_AUTH_HEADER -e ZAP_AUTH_HEADER_VALUE -e ZAP_AUTH_HEADER_SITE  -t ${docker_name} zap.sh -cmd -autorun /zap/wrk/${plan} ${cmdOptions}`);
+        let command = (`docker run -v ${workspace}:/zap/wrk/:rw --network="host" ${dockerEnvVars} -t ${docker_name} zap.sh -cmd -autorun /zap/wrk/${plan} ${cmdOptions}`);
 
         try {
             await exec.exec(command);

--- a/index.js
+++ b/index.js
@@ -6,13 +6,14 @@ async function run() {
     try {
         let workspace = process.env.GITHUB_WORKSPACE;
         let docker_name = core.getInput('docker_name', { required: true });
+        let dockerEnvVars = ["ZAP_AUTH_HEADER", "ZAP_AUTH_HEADER_VALUE", "ZAP_AUTH_HEADER_SITE"].concat(core.getMultilineInput('docker_env_vars', { required: false })).map(e => `-e ${e}`).join(' ');
         let plan = core.getInput('plan', { required: true });
         let cmdOptions = core.getInput('cmd_options');
 
         await exec.exec(`chmod a+w ${workspace}`);
 
         await exec.exec(`docker pull ${docker_name} -q`);
-        let command = (`docker run -v ${workspace}:/zap/wrk/:rw --network="host" -e ZAP_AUTH_HEADER -e ZAP_AUTH_HEADER_VALUE -e ZAP_AUTH_HEADER_SITE  -t ${docker_name} zap.sh -cmd -autorun /zap/wrk/${plan} ${cmdOptions}`);
+        let command = (`docker run -v ${workspace}:/zap/wrk/:rw --network="host" ${dockerEnvVars} -t ${docker_name} zap.sh -cmd -autorun /zap/wrk/${plan} ${cmdOptions}`);
 
         try {
             await exec.exec(command);


### PR DESCRIPTION
Add input `docker_env_vars` to allow to specify which env vars should be passed to the Docker container to be used by the plan.